### PR TITLE
README: Update supported ruby versions and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ s = SHA3::Digest.file("tests.sh")
 
 ## Development
 
-* Native build tools (e.g., GCC, Minigw, etc.)
+* Native build tools (e.g., GCC, MinGW, etc.)
 * Gems: rubygems-tasks, rake, rspec, yard
 
 ### Testing
@@ -109,7 +109,7 @@ Only a small subset of test vectors are included in the source repository; howev
 
 Supported Ruby versions:
 
-  - MRI Ruby 2.4 - 3.1
+  - MRI Ruby 2.6 - 3.1
 
 
 


### PR DESCRIPTION
Now this gem seems to support only Ruby 2.6+, so this PR updates section of supported Ruby versions.
And a typo has also been fixed.