### PR TITLE
Fix output length checks in KMAC

### DIFF
--- a/ext/sha3/kmac.c
+++ b/ext/sha3/kmac.c
@@ -432,7 +432,7 @@ static VALUE rb_sha3_kmac_self_digest(int argc, VALUE *argv, VALUE klass) {
     rb_scan_args(argc, argv, "41", &algorithm, &data, &output_length, &key, &customization);
 
     Check_Type(output_length, T_FIXNUM);
-    if (!NIL_P(output_length) && output_length <= INT2FIX(0)) {
+    if (!NIL_P(output_length) && NUM2INT(output_length) <= 0) {
         rb_raise(rb_eArgError, "class method digest does not support XOF mode");
     }
 
@@ -468,7 +468,7 @@ static VALUE rb_sha3_kmac_self_hexdigest(int argc, VALUE *argv, VALUE klass) {
     rb_scan_args(argc, argv, "41", &algorithm, &data, &output_length, &key, &customization);
 
     Check_Type(output_length, T_FIXNUM);
-    if (!NIL_P(output_length) && output_length <= INT2FIX(0)) {
+    if (!NIL_P(output_length) && NUM2INT(output_length) <= 0) {
         rb_raise(rb_eArgError, "class method hexdigest does not support XOF mode");
     }
 


### PR DESCRIPTION
## Summary
- fix how KMAC validates output length in class methods

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_6841f0606a7483219753d4c9f3b71544