### PR TITLE
fix(digest): guard cloned state from GC in squeeze

### DIFF
--- a/ext/sha3/digest.c
+++ b/ext/sha3/digest.c
@@ -625,6 +625,9 @@ static VALUE rb_sha3_digest_squeeze(VALUE self, VALUE length) {
         rb_raise(_sha3_digest_error_class, "failed to squeeze output");
     }
 
+    // Keep `copy` reachable so the GC can't free context_copy->state via rb_str_new above.
+    RB_GC_GUARD(copy);
+
     return str;
 }
 

--- a/spec/sha3_digest_core_spec.rb
+++ b/spec/sha3_digest_core_spec.rb
@@ -239,6 +239,35 @@ RSpec.describe SHA3::Digest do
 
         expect(result2).to eq(result1)
       end
+
+      describe '#squeeze and #hex_squeeze' do
+        it 'returns binary and hex output of the requested length' do
+          shake = described_class.new(:shake_128)
+          shake.update(test_data)
+
+          bin = shake.squeeze(32)
+          hex = shake.hex_squeeze(32)
+
+          expect(bin.bytesize).to eq(32)
+          expect(hex.length).to eq(64)
+          expect(hex).to eq(bin.unpack1('H*'))
+        end
+
+        it 'does not advance the original state across calls' do
+          shake = described_class.new(:shake_128, test_data)
+
+          first = shake.squeeze(32)
+          second = shake.squeeze(32)
+
+          expect(second).to eq(first)
+        end
+
+        it 'rejects non-SHAKE algorithms' do
+          digest = described_class.new(:sha3_256)
+          expect { digest.squeeze(32) }.to raise_error(SHA3::Digest::Error)
+          expect { digest.hex_squeeze(32) }.to raise_error(SHA3::Digest::Error)
+        end
+      end
     end
 
     # Test block_length method


### PR DESCRIPTION
Ensure `copy` reachable across the allocation and finalization with `RB_GC_GUARD`.

`rb_sha3_digest_squeeze` clones self via `rb_obj_clone` to preserve the original state, but the cloned VALUE (`copy`) is not referenced again after `get_sha3_digest_context` extracts the raw context pointer. An optimizing compiler is then free to stop preserving `copy` on the stack, so the subsequent `rb_str_new` allocation can become a GC point that reclaims the clone and frees `context_copy->state`. The following `Keccak_HashFinal` then dereferences freed memory and segfaults inside the function prologue.

We observed the following crash calling `SHA3::Digest::SHAKE_128#hex_squeeze` in our system:

		[BUG] Segmentation fault
		c:0043 CFUNC :hex_squeeze
		/gems/.../sha3_ext.so(Keccak_HashFinal+0x10)
		/gems/.../sha3_ext.so(rb_sha3_digest_squeeze+0xca)

Also add coverage for #squeeze / #hex_squeeze, which previously had no direct tests on SHA3::Digest.

_Disclosure: Claude Code is in use for investigation and patch suggestion. I've verified the fix fixes the crash, and have reviewed the patch before submission._